### PR TITLE
feat: add YOLO detection worker

### DIFF
--- a/src/worker/yolo.ts
+++ b/src/worker/yolo.ts
@@ -116,12 +116,12 @@ function nms(
   while (idxs.length > 0) {
     const current = idxs.shift()!;
     selected.push(current);
-    idxs = idxs.filter((i) => iou(boxes[current], boxes[i]) < threshold);
+    idxs = idxs.filter((i) => bboxIou(boxes[current], boxes[i]) < threshold);
   }
   return selected;
 }
 
-function iou(
+function bboxIou(
   a: [number, number, number, number],
   b: [number, number, number, number]
 ): number {


### PR DESCRIPTION
## Summary
- load YOLO model once and keep a singleton session for inference
- run detection on ImageData with NMS, filtering small boxes and extreme aspect ratios
- clarify IoU helper naming

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689033af7c8c832f889c3a8fcefa4490