### PR TITLE
feat: add dropzone component for worker detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "onnxruntime-web": "^1.22.0",
     "opencv.js": "^1.2.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-dropzone": "^14.2.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import Dropzone from './components/Dropzone';
 
 function App() {
   const [count, setCount] = useState(0)
 
   return (
     <>
+      <Dropzone />
       <div>
         <a href="https://vite.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />

--- a/src/components/Dropzone.tsx
+++ b/src/components/Dropzone.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+/**
+ * Dropzone component that accepts a single image file and sends it to the worker
+ * for object detection.
+ */
+export default function Dropzone() {
+  // create worker once
+  const worker = useMemo(
+    () => new Worker(new URL('../worker/core.ts', import.meta.url), { type: 'module' }),
+    []
+  );
+
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      if (acceptedFiles.length === 0) return;
+      const file = acceptedFiles[0];
+      const bitmap = await createImageBitmap(file);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(bitmap, 0, 0);
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const fileId = crypto.randomUUID();
+      worker.postMessage({ type: 'detect', payload: { fileId, imageData } });
+    },
+    [worker]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
+
+  return (
+    <div
+      {...getRootProps()}
+      style={{ border: '2px dashed #888', padding: '20px', textAlign: 'center' }}
+    >
+      <input {...getInputProps()} />
+      {isDragActive ? (
+        <p>Drop the image here ...</p>
+      ) : (
+        <p>Drag 'n' drop an image file here, or click to select.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Dropzone component that converts dropped files to ImageData and posts `detect` messages to the worker
- mount Dropzone in the main app
- declare react-dropzone dependency

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689039bd6bb4832fb86d3061feb0b84c