### PR TITLE
Add output panel for profile selection

### DIFF
--- a/public/output_profiles.json
+++ b/public/output_profiles.json
@@ -1,0 +1,14 @@
+{
+  "default": {
+    "sizes": [
+      { "name": "thumb", "width": 64, "height": 64 },
+      { "name": "preview", "width": 128, "height": 128 }
+    ]
+  },
+  "psd": {
+    "sizes": [
+      { "name": "full", "width": 1024, "height": 768 }
+    ],
+    "exportPsd": true
+  }
+}

--- a/src/components/OutputPanel.tsx
+++ b/src/components/OutputPanel.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ComposePayload } from './CanvasEditor';
+import type { ResizeSpec } from '../worker/opencv';
+
+interface OutputProfile {
+  sizes: ResizeSpec[];
+  exportPsd?: boolean;
+}
+
+type OutputProfiles = Record<string, OutputProfile>;
+
+interface OutputPanelProps {
+  payload?: ComposePayload;
+}
+
+export default function OutputPanel({ payload }: OutputPanelProps) {
+  const [profiles, setProfiles] = useState<OutputProfiles>({});
+  const [selected, setSelected] = useState<string>('');
+
+  const worker = useMemo(
+    () => new Worker(new URL('../worker/core.ts', import.meta.url), { type: 'module' }),
+    []
+  );
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/output_profiles.json');
+        if (!res.ok) return;
+        const json = (await res.json()) as OutputProfiles;
+        setProfiles(json);
+        const keys = Object.keys(json);
+        if (keys.length > 0) setSelected(keys[0]);
+      } catch (err) {
+        console.error('Failed to load output_profiles.json', err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleRun = () => {
+    if (!payload) return;
+    const profile = profiles[selected];
+    if (!profile) return;
+    const composePayload: ComposePayload = {
+      ...payload,
+      sizes: profile.sizes,
+      exportPsd: profile.exportPsd ?? payload.exportPsd,
+    };
+    worker.postMessage({ type: 'compose', payload: composePayload });
+  };
+
+  return (
+    <div>
+      <select value={selected} onChange={(e) => setSelected(e.target.value)}>
+        {Object.keys(profiles).map((key) => (
+          <option key={key} value={key}>
+            {key}
+          </option>
+        ))}
+      </select>
+      <button onClick={handleRun}>Run</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add OutputPanel component to pick an output profile and trigger worker composition
- define sample output profiles

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68903c519a90832fb1c242882934caf9