### PR TITLE
Add worker detection test

### DIFF
--- a/src/test/detect.test.ts
+++ b/src/test/detect.test.ts
@@ -1,9 +1,77 @@
-// src/test/detect.test.ts
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
-// ★不要な JSON 断片を削除して、このようなテストだけ残す
-describe('dummy detect', () => {
-  test('always true', () => {
-    expect(true).toBe(true);
+vi.mock('onnxruntime-web', () => {
+  class Tensor {
+    type: string;
+    data: Float32Array;
+    dims: number[];
+    constructor(type: string, data: Float32Array, dims: number[]) {
+      this.type = type;
+      this.data = data;
+      this.dims = dims;
+    }
+  }
+  class InferenceSession {
+    static async create(_path: string) {
+      return new InferenceSession();
+    }
+    inputNames = ['input'];
+    outputNames = ['output'];
+    async run(_feeds: Record<string, Tensor>) {
+      return {
+        output: {
+          dims: [1, 6, 1],
+          data: new Float32Array([320, 320, 64, 128, 0.9, 0.1])
+        }
+      };
+    }
+  }
+  return { Tensor, InferenceSession };
+});
+
+class MockContext {
+  imageData: any;
+  constructor(public width: number, public height: number) {}
+  putImageData(imageData: any) {
+    this.imageData = imageData;
+  }
+  drawImage() {
+    this.imageData = { data: new Uint8ClampedArray(640 * 640 * 4) };
+  }
+  getImageData() {
+    return this.imageData;
+  }
+}
+class MockCanvas {
+  ctx: MockContext;
+  constructor(public width: number, public height: number) {
+    this.ctx = new MockContext(width, height);
+  }
+  getContext() {
+    return this.ctx;
+  }
+}
+(globalThis as any).OffscreenCanvas = MockCanvas;
+
+import { detect } from '../worker/yolo';
+
+describe('worker detect', () => {
+  test('returns expected predictions', async () => {
+    const width = 640;
+    const height = 640;
+    const imageData = {
+      data: new Uint8ClampedArray(width * height * 4),
+      width,
+      height
+    } as unknown as ImageData;
+
+    const preds = await detect(imageData);
+
+    expect(preds).toHaveLength(1);
+    expect(preds[0]).toMatchObject({
+      bbox: [288, 256, 64, 128],
+      classId: 0
+    });
+    expect(preds[0].score).toBeCloseTo(0.9, 5);
   });
 });

--- a/src/worker/yolo.ts
+++ b/src/worker/yolo.ts
@@ -116,7 +116,11 @@ function nms(
   while (idxs.length > 0) {
     const current = idxs.shift()!;
     selected.push(current);
-    idxs = idxs.filter((i) => bboxIou(boxes[current], boxes[i]) < threshold);
+    for (let i = idxs.length - 1; i >= 0; i--) {
+      if (bboxIou(boxes[current], boxes[idxs[i]]) >= threshold) {
+        idxs.splice(i, 1);
+      }
+    }
   }
   return selected;
 }


### PR DESCRIPTION
## Summary
- add unit test verifying worker `detect` output without external image file
- refactor NMS to prune indices in place

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68903d80999c832f960a22e49eac2dc1