### PR TITLE
fix: resolve react asset path in visual test

### DIFF
--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -1,0 +1,6 @@
+import path from 'node:path';
+
+// Resolve react.svg relative to the test directory
+const reactSvgPath = path.resolve(__dirname, '../src/assets/react.svg');
+
+export { reactSvgPath };


### PR DESCRIPTION
## Summary
- resolve react.svg asset path relative to the test file

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68905bcb1990832fbc5fb75e4c450579