### PR TITLE
chore(test): allow small diff in visual snapshot

### DIFF
--- a/src/test/visual.spec.ts
+++ b/src/test/visual.spec.ts
@@ -5,7 +5,12 @@ import { describe, test, expect } from 'vitest';
 // まずはスキップしておく方法 ①
 describe.skip('visual regression', () => {
   test('placeholder', () => {
-    expect(true).toBe(true);
+    // Example snapshot comparison with a small allowed pixel difference
+    const dummy = new Uint8Array([0]);
+    expect(dummy).toMatchSnapshot({
+      maxDiffPixels: 1,
+      maxDiffPixelRatio: 0.01
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- allow a tiny pixel difference when matching visual snapshots

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68905bcb58f8832fa3974728d0db1539