### PR TITLE
fix typing and build configuration

### DIFF
--- a/src/components/CanvasEditor.tsx
+++ b/src/components/CanvasEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { fabric } from 'fabric';
+import * as fabric from 'fabric';
+import type { Canvas as FabricCanvas } from 'fabric';
 import type { ResizeSpec } from '../worker/opencv';
 
 export interface ComposePayload {
@@ -39,14 +40,16 @@ export default function CanvasEditor({
     ctx.drawImage(image, 0, 0);
     const dataUrl = tmp.toDataURL();
 
-    const fabricCanvas = new fabric.Canvas(canvasElement, {
+    const fabricCanvas: FabricCanvas = new fabric.Canvas(canvasElement, {
       selection: false,
     });
     fabricCanvas.setWidth(image.width);
     fabricCanvas.setHeight(image.height);
 
-    fabric.Image.fromURL(dataUrl, (img) => {
-      fabricCanvas.setBackgroundImage(img, fabricCanvas.renderAll.bind(fabricCanvas));
+    function loadImage(img: HTMLImageElement) {
+      const bgImage = new fabric.Image(img);
+      fabricCanvas.backgroundImage = bgImage;
+      fabricCanvas.renderAll();
 
       const rect = new fabric.Rect({
         left: initialBBox[0],
@@ -88,7 +91,9 @@ export default function CanvasEditor({
       rect.on('scaling', report);
 
       report();
-    });
+    }
+
+    fabric.util.loadImage(dataUrl).then(loadImage);
 
     return () => {
       fabricCanvas.dispose();

--- a/src/test/detect.test.ts
+++ b/src/test/detect.test.ts
@@ -53,10 +53,9 @@ class MockCanvas {
 }
 (globalThis as any).OffscreenCanvas = MockCanvas;
 
-import { detect } from '../worker/yolo';
-
 describe('worker detect', () => {
   test('returns expected predictions', async () => {
+    const { detect } = await import('../worker/yolo');
     const width = 640;
     const height = 640;
     const imageData = {

--- a/src/test/visual.spec.ts
+++ b/src/test/visual.spec.ts
@@ -1,16 +1,18 @@
 // src/test/visual.spec.ts
 import { describe, test, expect } from 'vitest';
+import pixelmatch from 'pixelmatch';
 
 // 将来 Playwright で画像比較を書く予定なら
 // まずはスキップしておく方法 ①
 describe.skip('visual regression', () => {
   test('placeholder', () => {
-    // Example snapshot comparison with a small allowed pixel difference
-    const dummy = new Uint8Array([0]);
-    expect(dummy).toMatchSnapshot({
-      maxDiffPixels: 1,
-      maxDiffPixelRatio: 0.01
-    });
+    const w = 10;
+    const h = 10;
+    const img1 = { data: new Uint8Array(w * h * 4) };
+    const img2 = { data: new Uint8Array(w * h * 4) };
+    const diffBuf = new Uint8Array(w * h * 4);
+    const diff = pixelmatch(img1.data, img2.data, diffBuf, w, h);
+    expect(diff).toBeLessThan(50);
   });
 });
 

--- a/src/types/opencv.d.ts
+++ b/src/types/opencv.d.ts
@@ -1,0 +1,4 @@
+declare module 'opencv.js' {
+  const cv: any;
+  export default cv;
+}

--- a/src/worker/core.ts
+++ b/src/worker/core.ts
@@ -1,6 +1,10 @@
-import { init as initYolo, detect as detectYolo, Prediction } from './yolo';
-import { cropAndResize, ResizeSpec } from './opencv';
-import { createPsd, PsdLayer } from './psd';
+import type { Prediction } from './yolo';
+import type { ResizeSpec } from './opencv';
+import type { PsdLayer } from './psd';
+
+import { init as initYolo, detect as detectYolo } from './yolo';
+import { cropAndResize } from './opencv';
+import { createPsd } from './psd';
 
 interface InitMessage {
   type: 'init';

--- a/src/worker/opencv.ts
+++ b/src/worker/opencv.ts
@@ -10,7 +10,7 @@ export interface ResizeSpec {
   pad?: PadOption;
 }
 
-let cv: any | null = null;
+let cv: any;
 let cvReady: Promise<void> | null = null;
 
 async function init() {

--- a/src/worker/psd.ts
+++ b/src/worker/psd.ts
@@ -26,12 +26,16 @@ export async function createPsd(
 ): Promise<Blob | null> {
   if (!exportPsd) return null;
 
-  const children = layers.map((layer) => ({
-    name: layer.name,
-    top: layer.top ?? 0,
-    left: layer.left ?? 0,
-    canvas: bitmapToCanvas(layer.image),
-  }));
+  const children = layers.map((layer) => {
+    const offscreen = bitmapToCanvas(layer.image);
+    const canvasEl = offscreen as unknown as HTMLCanvasElement;
+    return {
+      name: layer.name,
+      top: layer.top ?? 0,
+      left: layer.left ?? 0,
+      canvas: canvasEl,
+    };
+  });
 
   const buffer = writePsd({ width, height, children });
   return new Blob([buffer], { type: 'image/vnd.adobe.photoshop' });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,7 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
@@ -19,7 +19,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "files": [],
+  "compilerOptions": {
+    "typeRoots": ["./src/types", "./node_modules/@types"],
+    "verbatimModuleSyntax": false
+  },
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,7 +9,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "moduleDetection": "force",
     "noEmit": true,
 
@@ -17,7 +17,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,13 +3,16 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
-  base: '/imagetool/', 
+  base: '/imagetool/',
   plugins: [
     react(),
     VitePWA({
       strategies: 'generateSW',   // ← 変更
       registerType: 'autoUpdate', // 任意: 新 SW を自動適用
       includeAssets: ['favicon.svg'],
+      workbox: {
+        maximumFileSizeToCacheInBytes: 50 * 1024 * 1024
+      },
       manifest: {
         name: 'Image Crop & Layout',
         short_name: 'ImgTool',
@@ -23,5 +26,8 @@ export default defineConfig({
         ]
       }
     })
-  ]
+  ],
+  worker: {
+    format: 'es'
+  }
 });


### PR DESCRIPTION
## Summary
- refine Fabric imports and image loading in CanvasEditor
- move worker type imports to type-only and adjust build configs
- simplify tests with dynamic import and pixel comparison

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6890a8f559cc832faa46956ee2fc2656