### PR TITLE
feat: add usage accordion

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,23 @@
 .read-the-docs {
   color: #888;
 }
+
+.usage-button {
+  margin-bottom: 1rem;
+}
+
+.usage-accordion {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  text-align: left;
+  padding: 0 1rem;
+  margin-bottom: 1rem;
+}
+
+.usage-accordion.open {
+  max-height: 500px;
+  padding: 1rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,22 @@ import Dropzone from './components/Dropzone';
 
 function App() {
   const [count, setCount] = useState(0)
+  const [showUsage, setShowUsage] = useState(false)
 
   return (
     <>
+      <button className="usage-button" onClick={() => setShowUsage((v) => !v)}>
+        使い方
+      </button>
+      <div className={`usage-accordion${showUsage ? ' open' : ''}`}>
+        <h2>使い方</h2>
+        <p>PNG や JPEG 形式の画像ファイルを1枚用意してください。</p>
+        <ol>
+          <li>中央のドロップエリアに画像をドラッグ＆ドロップするか、クリックして選択します。</li>
+          <li>選択された画像はブラウザ上で解析され、結果が表示されます。</li>
+        </ol>
+        <p>特別なフォルダ構造やファイル名の制限はありません。ローカルに保存した画像をそのまま使用できます。</p>
+      </div>
       <Dropzone />
       <div>
         <a href="https://vite.dev" target="_blank">


### PR DESCRIPTION
## Summary
- add a Japanese "使い方" accordion with instructions on preparing images
- style accordion and toggle button with simple animation

## Testing
- `pnpm lint` *(fails: '_path' is defined but never used')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891be9b2570832f99fd0c65dc2ff5e5