### PR TITLE
fix: remove duplicate heading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -326,7 +326,6 @@ function AppContent() {
           📁 現在の保存先: <strong>{outputRootStatus.dirName}</strong>
         </div>
       )}
-      <h1>画像処理ツール</h1>
       <button className="usage-button" onClick={() => setShowUsage((v) => !v)}>
         使い方
       </button>


### PR DESCRIPTION
## Summary
- remove the redundant "画像処理ツール" heading from the usage controls to avoid duplicate h1 tags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf606d44c832fa3b4f62fb7c80763